### PR TITLE
ex28: Makefile: fix egrep regex split

### DIFF
--- a/ex28/c-skeleton/Makefile
+++ b/ex28/c-skeleton/Makefile
@@ -50,6 +50,6 @@ install: all
 # The Checker
 check:
 	@echo Files with potentially dangerous functions.
-	@egrep '[^_.>a-zA-Z0-9](str(n?cpy|n?cat|xfrm|n?dup|str|pbrk|tok|_)\
-		|stpn?cpy|a?sn?printf|byte_)' $(SOURCES) || true
+	@egrep -e '[^_.>a-zA-Z0-9]str(n?cpy|n?cat|xfrm|n?dup|str|pbrk|tok|_)' \
+		-e '[^_.>a-zA-Z0-9](stpn?cpy|a?sn?printf|byte_)' $(SOURCES) || true
 


### PR DESCRIPTION
Fix egrep error: "grep: Trailing backslash".