### PR TITLE
update ex30.c

### DIFF
--- a/ex30/ex30.c
+++ b/ex30/ex30.c
@@ -1,6 +1,6 @@
 #include "minunit.h"
 
-char *test_dlopen(int stuff)
+char *test_dlopen()
 {
     return NULL;
 }


### PR DESCRIPTION
I kept getting this bug, can we lose the "int stuff"? int stuff isn't in the book...
-----------------------------------------------------------------
src/ex30.c:30:5: error: too few arguments to function call, single argument 'stuff' was not specified
    mu_run_test(test_dlopen);
    ^           ~~~~~~~~~~~
src/minunit.h:14:20: note: expanded from macro 'mu_run_test'
    message = test(); tests_run++; if (message) return message;
                   ^
src/ex30.c:3:1: note: 'test_dlopen' declared here
char *test_dlopen(int stuff)
^
-----------------------------------------------------------------