### PR TITLE
Fixed why Y in Why was falling through the cracks

### DIFF
--- a/ex10/ex10.c
+++ b/ex10/ex10.c
@@ -43,8 +43,8 @@ int main(int argc, char *argv[])
                 if (i > 2) {
                     // it's only sometimes Y
                     printf("%d: 'Y'\n", i);
+                    break;
                 }
-                break;
 
             default:
                 printf("%d: %c is not a vowel\n", i, letter);


### PR DESCRIPTION
Moved break to within the if statement allowing fall through to default.

Currently running the example for the string "Why" will only print "Not a vowel" for two out of the three lines. 

0: W is not a vowel
1: h is not a vowel

'y' falls through the cracks