### PR TITLE
Fix typo in ex19.c: s/ex20/ex19/g

### DIFF
--- a/ex19/ex19.c
+++ b/ex19/ex19.c
@@ -104,7 +104,7 @@ int main(int argc, char *argv[])
     test_log_warn();
     test_log_info();
 
-    check(test_check("ex20.c") == 0, "failed with ex20.c");
+    check(test_check("ex19.c") == 0, "failed with ex19.c");
     check(test_check(argv[1]) == -1, "failed with argv");
     check(test_sentinel(1) == 0, "test_sentinel failed.");
     check(test_sentinel(100) == -1, "test_sentinel failed.");


### PR DESCRIPTION
Hi,

There is I believe a typo in your code.  The exercise is 19 and the file name in test_check used in the file doesn't match up...

Thank you.